### PR TITLE
Implement basic REPL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require github.com/stretchr/testify v1.7.0
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/Sirupsen/logrus v1.8.1
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 

--- a/main.go
+++ b/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"github.com/jcmaunsell/rhesus/repl"
+	"os"
+	"os/user"
+)
+
+func main() {
+	usr, err := user.Current()
+	if err != nil {
+		panic(fmt.Errorf("could not get username: %w", err))
+	}
+	fmt.Printf("Hi %s! Welcome to Rhesus.\n", usr.Username)
+	fmt.Println("You can enter Monkey commands here.")
+	repl.New(os.Stderr).Start(os.Stdin, os.Stdout)
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -1,0 +1,51 @@
+package repl
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/jcmaunsell/rhesus/lexer"
+	"github.com/jcmaunsell/rhesus/token"
+	"io"
+	"log"
+)
+
+const PROMPT = "> "
+
+type REPL interface {
+	Start(in io.Reader, out io.Writer)
+}
+
+type repl struct {
+	logger *log.Logger
+}
+
+func New(stderr io.Writer) REPL {
+	return &repl{log.New(stderr, "", log.Ldate|log.Ltime|log.Llongfile)}
+}
+
+func (r *repl) Start(in io.Reader, out io.Writer) {
+	scanner := bufio.NewScanner(in)
+
+	for {
+		if _, err := fmt.Fprintf(out, PROMPT); err != nil {
+			r.logger.Println(fmt.Errorf("could not print prompt: %w", err))
+			return
+		}
+		notDone := scanner.Scan()
+		if !notDone {
+			if err := scanner.Err(); err != nil {
+				r.logger.Println(fmt.Errorf("could not scan input: %w", err))
+			}
+			return
+		}
+
+		l := lexer.New(scanner.Text())
+
+		for tok := l.NextToken(); tok != token.EndOfFile; tok = l.NextToken() {
+			if _, err := fmt.Fprintf(out, "%+v\n", tok); err != nil {
+				r.logger.Println(fmt.Errorf("could not print token: %w", err))
+				return
+			}
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,5 @@
+# github.com/Sirupsen/logrus v1.8.1
+## explicit
 # github.com/davecgh/go-spew v1.1.0
 ## explicit
 github.com/davecgh/go-spew/spew


### PR DESCRIPTION
This PR implements a basic [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) for the Monkey language. It can be run via `$ go run main.go` in the base project directory.

This corresponds to section 1.5 of _Writing an Interpreter in Go_.